### PR TITLE
Minor edits in the PyTorch Installation Blog

### DIFF
--- a/_posts/2021-07-25-Installing-PyTorch.md
+++ b/_posts/2021-07-25-Installing-PyTorch.md
@@ -9,7 +9,7 @@ show_sidebar: false
 
 Hi Everyone! In this blog post, we'll be discussing setting up a developer environment for PyTorch. Our goal is to build PyTorch from source on any of the Linux distributions. Presently, I'm working on the Ubuntu 20.04 distribution of Linux in WSL (Windows Subsystem Linux). You can install any other Ubuntu version of your choice, the procedure will be the same because all the Ubuntu versions are Debian-based. Enjoy the installation process! Yey!!  
 
-In case you are interesting in watching a video tutorial on this, jump to the [Video Section](#Video Tutorial).
+In case you are interesting in watching a video tutorial on this, jump to the "Video Tutorial" section towards the end.
 
 ## Step 1: Installing Anaconda
 

--- a/_posts/2021-07-25-Installing-PyTorch.md
+++ b/_posts/2021-07-25-Installing-PyTorch.md
@@ -9,7 +9,7 @@ show_sidebar: false
 
 Hi Everyone! In this blog post, we'll be discussing setting up a developer environment for PyTorch. Our goal is to build PyTorch from source on any of the Linux distributions. Presently, I'm working on the Ubuntu 20.04 distribution of Linux in WSL (Windows Subsystem Linux). You can install any other Ubuntu version of your choice, the procedure will be the same because all the Ubuntu versions are Debian-based. Enjoy the installation process! Yey!!  
 
-In case you are interesting in watching a video tutorial on this, jump to the "Video Tutorial" section towards the end.
+In case you are interesting in watching a video tutorial on this, jump to the [Video](#video) section towards the end.
 
 ## Step 1: Installing Anaconda
 
@@ -146,7 +146,7 @@ To check `CMAKE_PREFIX_PATH`, use: `echo $CMAKE_PREFIX_PATH` command.
 
 Building PyTorch can take a long, so be patient! We succeeded in installing PyTorch from the source. 
 
-## Video Tutorial
+## Video
 
 Checkout the video below on our [YouTube Channel](https://www.youtube.com/channel/UCV1XiuvBIXrs5qMvsyueqrg):
 


### PR DESCRIPTION
Not sure how to link sections in markdown (https://malloc-42.github.io/intro/2021/07/25/Installing-PyTorch/ - the section is not linked correctly). We can experiment with this later, for now - let's fix this.

Update: resolved by the comment from @khushi-411 here: https://github.com/malloc-42/malloc-42.github.io/pull/11#issuecomment-898875962.

cc: @kshitij12345 @khushi-411 